### PR TITLE
Add addition practice level

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,9 +184,87 @@
           <button id="gotable">Go!</button>`);
         document.getElementById('gotable').onclick = () => {
           hideOverlay();
-          startFillMode();
+          if(state.level === 1) startAdditionPractice();
+          else startFillMode();
         };
       },3000);
+    };
+  }
+
+  // ADDITION PRACTICE (level 1)
+  function startAdditionPractice(){
+    const n = state.currentTable;
+    let step = 0, mistakes = 0, timerId = null;
+
+    main.innerHTML = `
+      <h2>Practice Adding ${n}</h2>
+      <p>Time: <span id="time">60</span>s |
+         Mistakes: <span id="mcount">0</span>/2</p>
+      <div id="addQ">0 + ${n} = </div>
+      <input id="addAns" class="answer" disabled />
+      <button id="addSubmit">Start</button>
+    `;
+
+    const btn   = document.getElementById('addSubmit');
+    const input = document.getElementById('addAns');
+    const qEl   = document.getElementById('addQ');
+    const timeE = document.getElementById('time');
+    const mE    = document.getElementById('mcount');
+
+    btn.onclick = () => {
+      if(btn.textContent==='Start'){
+        audioCountdown.loop = true;
+        audioCountdown.play();
+        btn.textContent = 'Submit';
+        input.disabled = false;
+        input.focus();
+        timerId = setInterval(()=>{
+          let t = parseInt(timeE.textContent,10) - 1;
+          timeE.textContent = t;
+          if(t <= 0){
+            clearInterval(timerId);
+            audioCountdown.pause();
+            return gameOver();
+          }
+        },1000);
+      } else {
+        const ans = parseInt(input.value,10);
+        if(ans === (step+1)*n){
+          state.score += 5;
+          audioSuccess.play();
+          step++;
+          updateHeader();
+          if(step === 10){
+            clearInterval(timerId);
+            audioCountdown.pause();
+            audioLevelUp.play();
+            showOverlay(`
+              <h2>${CELEBRATIONS[Math.floor(Math.random()*CELEBRATIONS.length)]}</h2>
+              <button id="contFill">Continue</button>`);
+            document.getElementById('contFill').onclick = () => {
+              hideOverlay();
+              startFillMode();
+            };
+            return;
+          }
+          qEl.textContent = `${step*n} + ${n} = `;
+          input.value = '';
+          input.focus();
+        } else {
+          mistakes++;
+          state.score -= 2;
+          audioFail.play();
+          updateHeader();
+          mE.textContent = mistakes;
+          if(mistakes > 2){
+            clearInterval(timerId);
+            audioCountdown.pause();
+            return gameOver();
+          }
+          input.value = '';
+          input.focus();
+        }
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
- add a new `startAdditionPractice` function that quizzes players on repeated addition
- call addition practice when level 1 starts via the wheel overlay

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686d326762b48333bc436dcc46abfc54