### PR TITLE
Fix countdown audio restart

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,6 +360,7 @@
     btn.onclick = () => {
       if(btn.textContent==='Start'){
         audioCountdown.loop = true;
+        audioCountdown.currentTime = 0;
         audioCountdown.play();
         btn.textContent = 'Submit';
         input.disabled = false;
@@ -430,7 +431,9 @@
         <p>Score: ${state.score}</p>
         <button id="replay">Play Again</button>`);
       document.getElementById('replay').onclick = () => {
-        hideOverlay(); startGame();
+        audioCountdown.currentTime = 0;
+        hideOverlay();
+        startGame();
       };
     },200);
   }
@@ -448,7 +451,9 @@
         <p>Score: ${state.score}</p>
         <button id="replay2">Play Again</button>`);
       document.getElementById('replay2').onclick = () => {
-        hideOverlay(); startGame();
+        audioCountdown.currentTime = 0;
+        hideOverlay();
+        startGame();
       };
     },200);
   }


### PR DESCRIPTION
## Summary
- ensure countdown starts from the beginning of the audio in quiz mode
- reset audio position when replaying after game over or winning

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686d3a0b8ea08333a94244c6ae056bc6