### PR TITLE
Remove time limit and factor time into scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a small web-based game to practice multiplication table
 ## Playing
 
 1. Open `index.html` in any modern browser. No additional setup is required.
-2. Follow the prompts to spin the wheel, practice addition and multiplication, and progress through the levels.
+2. Follow the prompts to spin the wheel, practice addition and multiplication, and progress through the levels. There is no time limit while playing, but the time you take and your mistakes determine the points you earn at the end of each level.
 3. Scores and the current level are saved in `localStorage`, so your progress and high scores persist between sessions.
 
 Enjoy sharpening your math skills!

--- a/index.html
+++ b/index.html
@@ -193,12 +193,12 @@
   // ADDITION PRACTICE (level 1)
   function startAdditionPractice(){
     const n = state.currentTable;
-    let step = 0, mistakes = 0, timerId = null;
+    let step = 0, mistakes = 0;
+    let startTime = null;
 
     main.innerHTML = `
       <h2>Practice Adding ${n}</h2>
-      <p>Time: <span id="time">60</span>s |
-         Mistakes: <span id="mcount">0</span>/2</p>
+      <p>Mistakes: <span id="mcount">0</span>/2</p>
       <div id="addQ">0 + ${n} = </div>
       <input id="addAns" class="answer" disabled />
       <button id="addSubmit">Start</button>
@@ -207,38 +207,29 @@
     const btn   = document.getElementById('addSubmit');
     const input = document.getElementById('addAns');
     const qEl   = document.getElementById('addQ');
-    const timeE = document.getElementById('time');
     const mE    = document.getElementById('mcount');
 
     btn.onclick = () => {
       if(btn.textContent==='Start'){
-        audioCountdown.loop = true;
-        audioCountdown.play();
         btn.textContent = 'Submit';
         input.disabled = false;
         input.focus();
-        timerId = setInterval(()=>{
-          let t = parseInt(timeE.textContent,10) - 1;
-          timeE.textContent = t;
-          if(t <= 0){
-            clearInterval(timerId);
-            audioCountdown.pause();
-            return gameOver();
-          }
-        },1000);
+        startTime = Date.now();
       } else {
         const ans = parseInt(input.value,10);
         if(ans === (step+1)*n){
-          state.score += 5;
           audioSuccess.play();
           step++;
-          updateHeader();
           if(step === 10){
-            clearInterval(timerId);
-            audioCountdown.pause();
+            const timeTaken = Math.round((Date.now() - startTime)/1000);
+            const points = Math.max(0, 50 - mistakes*5 - timeTaken);
+            state.score += points;
             audioLevelUp.play();
+            updateHeader();
             showOverlay(`
               <h2>${CELEBRATIONS[Math.floor(Math.random()*CELEBRATIONS.length)]}</h2>
+              <p>Time: ${timeTaken}s | Errors: ${mistakes}</p>
+              <p>Points: ${points}</p>
               <button id="contFill">Continue</button>`);
             document.getElementById('contFill').onclick = () => {
               hideOverlay();
@@ -251,13 +242,9 @@
           input.focus();
         } else {
           mistakes++;
-          state.score -= 2;
           audioFail.play();
-          updateHeader();
           mE.textContent = mistakes;
           if(mistakes > 2){
-            clearInterval(timerId);
-            audioCountdown.pause();
             return gameOver();
           }
           input.value = '';
@@ -272,6 +259,7 @@
     const n = state.currentTable;
     const bmap={1:4,3:4,5:5,7:6,9:7};
     const blankCount = bmap[state.level]||4;
+    const startTime = Date.now();
     const allowedMist = Math.floor(blankCount * 0.33);
     const all = Array.from({length:10},(_,i)=>i+1);
     const blanks = shuffle(all.slice()).slice(0,blankCount);
@@ -319,12 +307,15 @@
           return gameOver();
         }
         // Success
+        const timeTaken = Math.round((Date.now() - startTime)/1000);
+        const points = Math.max(0, blanks.length*10 - mistakes*5 - timeTaken);
+        state.score += points;
         audioLevelUp.play();
-        state.score += blanks.length*10 - mistakes*5;
         updateHeader();
         showOverlay(`
           <h2>🎉 ${CELEBRATIONS[Math.floor(Math.random()*CELEBRATIONS.length)]}</h2>
-          <p>Errors: ${mistakes}/${allowedMist}</p>
+          <p>Time: ${timeTaken}s | Errors: ${mistakes}/${allowedMist}</p>
+          <p>Points: ${points}</p>
           <button id="nextlvl">Next Level</button>`);
         document.getElementById('nextlvl').onclick = () => {
           hideOverlay();
@@ -339,13 +330,13 @@
   // QUIZ (even levels)
   function startQuiz(){
     const n = state.currentTable;
-    let mistakes=0, qIdx=0, timerId=null;
+    let mistakes=0, qIdx=0;
+    let startTime=null;
     const questions = shuffle(Array.from({length:10},(_,i)=>i+1));
 
     main.innerHTML = `
-      <h2>Table of ${n} — Quiz (120s, max 2 mistakes)</h2>
-      <p>Time: <span id="time">120</span>s |
-         Mistakes: <span id="mcount">0</span>/2</p>
+      <h2>Table of ${n} — Quiz (max 2 mistakes)</h2>
+      <p>Mistakes: <span id="mcount">0</span>/2</p>
       <div id="question">Press Start</div>
       <input id="qans" class="answer" disabled />
       <button id="submitQ">Start</button>
@@ -353,49 +344,38 @@
 
     const btn   = document.getElementById('submitQ');
     const input = document.getElementById('qans');
-    const timeE = document.getElementById('time');
     const mE    = document.getElementById('mcount');
 
     btn.onclick = () => {
       if(btn.textContent==='Start'){
-        audioCountdown.loop = true;
-        audioCountdown.currentTime = 0;
-        audioCountdown.play();
         btn.textContent = 'Submit';
         input.disabled = false;
         input.focus();
-        timerId = setInterval(()=>{
-          let t = parseInt(timeE.textContent,10) - 1;
-          timeE.textContent = t;
-          if(t <= 0){
-            clearInterval(timerId);
-            audioCountdown.pause();
-            return gameOver();
-          }
-        },1000);
+        startTime = Date.now();
         showNext();
       } else {
         const ans = parseInt(input.value,10);
         const corr= n * questions[qIdx];
         if(ans===corr){
-          state.score+=10; audioSuccess.play();
+          audioSuccess.play();
         } else {
-          mistakes++; state.score-=5; audioFail.play();
+          mistakes++; audioFail.play();
         }
-        updateHeader();
         mE.textContent = mistakes;
         if(mistakes>2){
-          clearInterval(timerId);
-          audioCountdown.pause();
           return gameOver();
         }
         qIdx++;
         if(qIdx>=questions.length){
-          clearInterval(timerId);
-          audioCountdown.pause();
+          const timeTaken = Math.round((Date.now() - startTime)/1000);
+          const points = Math.max(0, 100 - mistakes*5 - timeTaken);
+          state.score += points;
           audioLevelUp.play();
+          updateHeader();
           showOverlay(`
             <h2>🎉 ${CELEBRATIONS[Math.floor(Math.random()*CELEBRATIONS.length)]}</h2>
+            <p>Time: ${timeTaken}s | Errors: ${mistakes}</p>
+            <p>Points: ${points}</p>
             <button id="nextlvl2">Next Level</button>`);
           document.getElementById('nextlvl2').onclick = () => {
             hideOverlay();


### PR DESCRIPTION
## Summary
- adjust README to document new scoring rules
- remove countdown timers from all levels
- calculate points at level completion based on time taken and mistakes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0ed55acc8333bb7f3767bcb4a670