### PR TITLE
Add Start button to fill-in mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a small web-based game to practice multiplication table
 
 1. Open `index.html` in any modern browser. No additional setup is required.
 
-2. Follow the prompts to spin the wheel, practice addition and multiplication, and progress through the levels. There is no time limit while playing, but the time you take and your mistakes determine the points you earn at the end of each level.
+2. Follow the prompts to spin the wheel, practice addition and multiplication, and progress through the levels. Each challenge begins when you press its **Start** button, and the time from starting until completion along with your mistakes determines the points you earn at the end of the level.
 
 3. Scores and the current level are saved in `localStorage`, so your progress and high scores persist between sessions.
 

--- a/index.html
+++ b/index.html
@@ -260,7 +260,7 @@
     const bmap={1:4,3:4,5:5,7:6,9:7};
     const blankCount = bmap[state.level]||4;
 
-    const startTime = Date.now();
+    let startTime = null;
     const allowedMist = Math.floor(blankCount * 0.33);
     const all = Array.from({length:10},(_,i)=>i+1);
     const blanks = shuffle(all.slice()).slice(0,blankCount);
@@ -273,11 +273,23 @@
             <td>${n} × ${i} =</td>
             <td>${
               blanks.includes(i)
-                ? `<input class="answer" id="ans${i}" />`
+                ? `<input class="answer" id="ans${i}" disabled />`
                 : `<strong>${n*i}</strong>`
             }</td>
           </tr>`).join('')}
-      </table>`;
+      </table>
+      <button id="fillStartBtn">Start</button>`;
+
+    const startBtn = document.getElementById('fillStartBtn');
+    startBtn.onclick = () => {
+      startBtn.remove();
+      blanks.forEach(j => {
+        const inp = document.getElementById(`ans${j}`);
+        inp.disabled = false;
+      });
+      document.getElementById(`ans${blanks[0]}`).focus();
+      startTime = Date.now();
+    };
 
 
     // Validate on blur


### PR DESCRIPTION
## Summary
- add a Start button to the Fill in the Blanks section and start timing after it is pressed
- explain Start buttons in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e45c31c3083338a309398fd371c1b