### PR TITLE
Handle spoken number homophones

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,12 +262,28 @@
     if(digitMatch) return parseInt(digitMatch[0],10);
 
     const words = cleaned.replace(/[^a-z\s-]/g,' ').split(/\s+/).filter(Boolean);
-    const map = {
+    const baseMap = {
       zero:0, one:1, two:2, three:3, four:4, five:5, six:6, seven:7, eight:8, nine:9,
       ten:10, eleven:11, twelve:12, thirteen:13, fourteen:14, fifteen:15, sixteen:16, seventeen:17, eighteen:18, nineteen:19,
       twenty:20, thirty:30, forty:40, fifty:50, sixty:60, seventy:70, eighty:80, ninety:90,
       hundred:100
     };
+
+    const map = { ...baseMap };
+    const homophones = {
+      zero: ['oh', 'o', 'owe'],
+      one: ['won'],
+      two: ['too', 'to'],
+      four: ['for', 'fore'],
+      eight: ['ate'],
+      forty: ['fourty']
+    };
+
+    Object.entries(homophones).forEach(([canonical, variants]) => {
+      const val = baseMap[canonical];
+      variants.forEach(v => map[v] = val);
+    });
+
     let total = 0; let current = 0; let found = false;
     words.forEach(w => {
       const val = map[w];


### PR DESCRIPTION
## Summary
- improve spoken number parsing by mapping common homophones (e.g., too/to, won, ate)
- retain existing numeric and word handling while extending recognition coverage

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a927444848333807978d38d9c114b)