### PR TITLE
Remove listening subtitle from addition practice

### DIFF
--- a/index.html
+++ b/index.html
@@ -523,7 +523,6 @@
     main.innerHTML = `
       <div class="card">
         <h2>Practice Adding ${n}</h2>
-        <p class="subtitle">Say each answer out loud. We'll keep listening until it's correct.</p>
         <div class="question" id="addQ">0 + ${n} = ?</div>
         <div class="heard-wrapper"><div class="heard-label">Heard:</div><div class="heard-number" id="addHeard"></div></div>
         <div class="voice-status" id="addStatus">Press start to begin listening.</div>


### PR DESCRIPTION
## Summary
- remove the subtitle line prompting spoken answers in the addition practice card

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a99d5b37c833392fdf4aea27930f5)